### PR TITLE
Fix for issue 15 "Bridges Wizard is empty in some cases"

### DIFF
--- a/GSDRoadUtility.cs
+++ b/GSDRoadUtility.cs
@@ -3131,8 +3131,9 @@ namespace GSD.Roads{
 
 	public static class GSDRoadUtil{
 		private const string FileSepString = "\n!!!! MICROGSD !!!!\n";
+        private const string FileSepStringCRLF = "\r\n!!!! MICROGSD !!!!\r\n";
 
-		public static Terrain GetTerrain(Vector3 tVect){
+        public static Terrain GetTerrain(Vector3 tVect){
 			return GetTerrain_Do(ref tVect);
 		}
 		private static Terrain GetTerrain_Do(ref Vector3 tVect){
@@ -3985,8 +3986,9 @@ namespace GSD.Roads{
 			}
 
 	        string tData = System.IO.File.ReadAllText(tPath);
-			string[] tSep = new string[1];
-			tSep[0] = FileSepString;
+			string[] tSep = new string[2];
+            tSep[0] = FileSepString;
+            tSep[1] = FileSepStringCRLF;
 			string[] tSplit = tData.Split(tSep,System.StringSplitOptions.RemoveEmptyEntries);
 
 			Splination.SplinatedMeshMaker SMM = null;
@@ -4222,8 +4224,9 @@ namespace GSD.Roads{
 				return null;
                 #else
 				string tData = System.IO.File.ReadAllText(tPath);
-				string[] tSep = new string[1];
-				tSep[0] = FileSepString;
+				string[] tSep = new string[2];
+                tSep[0] = FileSepString;
+                tSep[1] = FileSepStringCRLF;
 				string[] tSplit = tData.Split(tSep,System.StringSplitOptions.RemoveEmptyEntries);
 				int tSplitCount = tSplit.Length;
 				WizardObjectLibrary WOL = null;


### PR DESCRIPTION
This change adds a second split string that includes carriage returns, which allows the Wizard to correctly parse .gsd files that have had their line endings altered by Visual Studio, Git or other tools.