### PR TITLE
Can't create intersections by default

### DIFF
--- a/Editor/GSDSplineNEditor.cs
+++ b/Editor/GSDSplineNEditor.cs
@@ -1770,7 +1770,7 @@ public class GSDSplineNEditor : Editor {
 		bCreateIntersection = true;
 		iNode1 = tNode1;
 		iNode2 = tNode2;
-//    	Selection.activeGameObject = GSD.Roads.GSDIntersections.CreateIntersection(tNode1,tNode2);
+		Selection.activeGameObject = GSD.Roads.GSDIntersections.CreateIntersection(tNode1,tNode2);
 	}
 	
 	private void TriggerRoadUpdate(){


### PR DESCRIPTION
Small change, hope I don't make a conflict. Currently line 1773 is commented out, making it impossible to create intersections aside from the Unit Tests. With the large amount of code, finding this line, or even tracing this line, can be tricky. Spent around an hour trying to figure out why the Unit Test intersections were working while my own were not, so I think it's worth it to save the trouble for everyone else. The unitypackage has this problem too. Pull request #34 does not have this change (notice that line 1782 is still commented).